### PR TITLE
fix bentoml cli deployment update

### DIFF
--- a/src/bentoml_cli/deployment.py
+++ b/src/bentoml_cli/deployment.py
@@ -100,6 +100,7 @@ def add_deployment_command(cli: click.Group) -> None:
     )
     @click.option("-n", "--name", type=click.STRING, help="Deployment name")
     @click.option("--bento", type=click.STRING, help="Bento tag")
+    @click.option("--kube-namespace", type=click.STRING, help="Kubernetes namespace.")
     @output_option
     @click.pass_obj
     def update(  # type: ignore
@@ -107,6 +108,7 @@ def add_deployment_command(cli: click.Group) -> None:
         file: str | None,
         name: str | None,
         bento: str | None,
+        kube_namespace: str | None,
         output: t.Literal["json", "default"],
     ) -> DeploymentSchema:
         """Update a deployment on BentoCloud.
@@ -127,6 +129,7 @@ def add_deployment_command(cli: click.Group) -> None:
                 bento=bento,
                 context=shared_options.cloud_context,
                 latest_bento=True,
+                kube_namespace=kube_namespace,
             )
         else:
             raise click.BadArgumentUsage(


### PR DESCRIPTION

## What does this PR address?
Currently bentoml deploy update results in an error

     + Exception Group Traceback (most recent call last):
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/bin/bentoml", line 8, in <module>
      |     sys.exit(cli())
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
      |     return self.main(*args, **kwargs)
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/click/core.py", line 1055, in main
      |     rv = self.invoke(ctx)
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
      |     return _process_result(sub_ctx.command.invoke(sub_ctx))
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
      |     return _process_result(sub_ctx.command.invoke(sub_ctx))
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
      |     return ctx.invoke(self.callback, **ctx.params)
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/click/core.py", line 760, in invoke
      |     return __callback(*args, **kwargs)
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/bentoml_cli/utils.py", line 362, in wrapper
      |     return func(*args, **kwargs)
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/bentoml_cli/utils.py", line 333, in wrapper
      |     return_value = func(*args, **kwargs)
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/click/decorators.py", line 26, in new_func
      |     return f(get_current_context(), *args, **kwargs)
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/bentoml_cli/utils.py", line 290, in wrapper
      |     return func(*args, **kwargs)
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/click/decorators.py", line 38, in new_func
      |     return f(get_current_context().obj, *args, **kwargs)
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/bentoml_cli/deployment.py", line 125, in update
      |     res = client.deployment.update(
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/bentoml/_internal/cloud/deployment.py", line 192, in update
      |     kube_namespace = cls._get_default_kube_namespace(cluster_name, context)
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/bentoml/_internal/cloud/deployment.py", line 69, in _get_default_kube_namespace
      |     res = cloud_rest_client.get_cluster(cluster_name)
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/bentoml/_internal/cloud/client.py", line 514, in get_cluster
      |     return schema_from_json(resp.text, ClusterFullSchema)
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/bentoml/_internal/cloud/schemas.py", line 53, in schema_from_json
      |     return cloud_converter.structure(dct, cls)
      |   File "/Users/varunmallya/Projects/liveness-check/myvenv/lib/python3.9/site-packages/cattrs/converters.py", line 309, in structure
      |     return self._structure_func.dispatch(cl)(obj, cl)
      |   File "<cattrs generated structure bentoml._internal.cloud.schemas.ClusterFullSchema>", line 74, in structure_ClusterFullSchema
      |     if errors: raise __c_cve('While structuring ' + 'ClusterFullSchema', errors, __cl)
      | cattrs.errors.ClassValidationError: While structuring ClusterFullSchema (2 sub-exceptions)
      +-+---------------- 1 ----------------
        | Exception Group Traceback (most recent call last):
        |   File "<cattrs generated structure bentoml._internal.cloud.schemas.ClusterFullSchema>", line 60, in structure_ClusterFullSchema
        |     res['config'] = __c_structure_config(o['config'], __c_type_config)
        |   File "<cattrs generated structure bentoml._internal.cloud.schemas.ClusterConfigSchema>", line 19, in structure_ClusterConfigSchema
        |     if errors: raise __c_cve('While structuring ' + 'ClusterConfigSchema', errors, __cl)
        | cattrs.errors.ClassValidationError: While structuring ClusterConfigSchema (3 sub-exceptions)
        | Structuring class ClusterFullSchema @ attribute config
        +-+---------------- 1 ----------------
          | Traceback (most recent call last):
          |   File "<cattrs generated structure bentoml._internal.cloud.schemas.ClusterConfigSchema>", line 5, in structure_ClusterConfigSchema
          |     res['default_deployment_kube_namespace'] = __c_structure_default_deployment_kube_namespace(o['default_deployment_kube_namespace'])
          | TypeError: 'NoneType' object is not subscriptable
          | Structuring class ClusterConfigSchema @ attribute default_deployment_kube_namespace
          +---------------- 2 ----------------
          | Traceback (most recent call last):
          |   File "<cattrs generated structure bentoml._internal.cloud.schemas.ClusterConfigSchema>", line 10, in structure_ClusterConfigSchema
          |     res['ingress_ip'] = __c_structure_ingress_ip(o['ingress_ip'])
          | TypeError: 'NoneType' object is not subscriptable
          | Structuring class ClusterConfigSchema @ attribute ingress_ip
          +---------------- 3 ----------------
          | Traceback (most recent call last):
          |   File "<cattrs generated structure bentoml._internal.cloud.schemas.ClusterConfigSchema>", line 15, in structure_ClusterConfigSchema
          |     res['aws'] = __c_structure_aws(o['aws'])
          | TypeError: 'NoneType' object is not subscriptable
          | Structuring class ClusterConfigSchema @ attribute aws
          +------------------------------------
        +---------------- 2 ----------------
        | Traceback (most recent call last):
        |   File "<cattrs generated structure bentoml._internal.cloud.schemas.ClusterFullSchema>", line 70, in structure_ClusterFullSchema
        |     res['resource_instances'] = __c_structure_resource_instances(o['resource_instances'], __c_type_resource_instances)
        | KeyError: 'resource_instances'
        | Structuring class ClusterFullSchema @ attribute resource_instances

To resolve this we need to make the kube namespace as an available option for bentoml deployment update.

After adding kube-namespace option I was able to update the bento.

    DeploymentSchema(
        uid='6449dc4bbae4651436c0f50e6',
        created_at=datetime.datetime(2023, 4, 27, 2, 22, 3, 417954, tzinfo=tzutc()),
        updated_at=datetime.datetime(2023, 7, 26, 9, 50, 57, 826319, tzinfo=tzutc()),
        deleted_at=None,
        name='still-image-classifier',
        resource_type=<ResourceType.DEPLOYMENT: 'deployment'>,
        labels=[],...

<!--
Thanks for sending a pull request!

Congrats for making it this far! Here's a 🍱 for you. There are still a few steps ahead.

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
  - feat: (new feature for the user, not a new feature for build script)
  - fix: (bug fix for the user, not a fix to a build script)
  - docs: (changes to the documentation)
  - style: (formatting, missing semicolons, etc; no production code change)
  - refactor: (refactoring production code, eg. renaming a variable)
  - perf: (code changes that improve performance)
  - test: (adding missing tests, refactoring tests; no production code change)
  - chore: (updating grunt tasks etc; no production code change)
  - build: (changes that affect the build system or external dependencies)
  - ci: (changes to configuration files and scripts)
  - revert: (reverts a previous commit)

Describe your changes in detail. Attach screenshots here if appropriate.

Once you're done with this, someone from BentoML team or community member will help review your PR (see "Who can help review?" section for potential reviewers.). If no one has reviewed your PR after a week have passed, don't hesitate to post a new comment and ping @-the same person. Notifications sometimes get lost 🥲.
-->

<!-- Remove if not applicable -->

Fixes #(issue)

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [ ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ ] Does the code follow BentoML's code style, `pre-commit run -a` script has passed ([instructions](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#style-check-auto-formatting-type-checking))?
- [ ] Did you read through [contribution guidelines](https://github.com/bentoml/BentoML/blob/main/CONTRIBUTING.md#ways-to-contribute) and follow [development guidelines](https://github.com/bentoml/BentoML/blob/main/DEVELOPMENT.md#start-developing)?
- [ ] Did your changes require updates to the documentation? Have you updated
      those accordingly? Here are [documentation guidelines](https://github.com/bentoml/BentoML/tree/main/docs) and [tips on writting docs](https://github.com/bentoml/BentoML/tree/main/docs#writing-documentation).
- [ ] Did you write tests to cover your changes?

